### PR TITLE
Fully implicit login

### DIFF
--- a/.github/workflows/small-linux-test.yaml
+++ b/.github/workflows/small-linux-test.yaml
@@ -65,6 +65,6 @@ jobs:
 
       - name: Run download
         run: |
-          bazel run --action_env=MAYHEM_URL=${{ env.MAYHEM_URL }} --action_env=XDG_CONFIG_HOME="$HOME/.config" //examples:download_mayhemit
+          bazel build --action_env=MAYHEM_URL=${{ env.MAYHEM_URL }} --action_env=XDG_CONFIG_HOME="$HOME/.config" //examples:download_mayhemit
         env:
           MAYHEM_URL: ${{ env.MAYHEM_URL }}

--- a/.github/workflows/small-linux-test.yaml
+++ b/.github/workflows/small-linux-test.yaml
@@ -62,4 +62,9 @@ jobs:
           bazel build --action_env=MAYHEM_URL=${{ env.MAYHEM_URL }} --action_env=XDG_CONFIG_HOME="$HOME/.config" //examples:run_mayhemit
         env:
           MAYHEM_URL: ${{ env.MAYHEM_URL }}
-          MAYHEM_TOKEN: ${{ secrets.MAYHEM_TOKEN }}
+
+      - name: Run download
+        run: |
+          bazel run --action_env=MAYHEM_URL=${{ env.MAYHEM_URL }} --action_env=XDG_CONFIG_HOME="$HOME/.config" //examples:download_mayhemit
+        env:
+          MAYHEM_URL: ${{ env.MAYHEM_URL }}

--- a/.github/workflows/small-linux-test.yaml
+++ b/.github/workflows/small-linux-test.yaml
@@ -60,11 +60,13 @@ jobs:
       - name: Run bazel build
         run: |
           bazel build --action_env=MAYHEM_URL=${{ env.MAYHEM_URL }} --action_env=XDG_CONFIG_HOME="$HOME/.config" //examples:run_mayhemit
+        shell: bash
         env:
           MAYHEM_URL: ${{ env.MAYHEM_URL }}
 
       - name: Run download
         run: |
           bazel build --action_env=MAYHEM_URL=${{ env.MAYHEM_URL }} --action_env=XDG_CONFIG_HOME="$HOME/.config" //examples:download_mayhemit
+        shell: bash
         env:
           MAYHEM_URL: ${{ env.MAYHEM_URL }}

--- a/.github/workflows/small-win-test.yaml
+++ b/.github/workflows/small-win-test.yaml
@@ -67,5 +67,6 @@ jobs:
       - name: Run download
         run: |
           bazel build --action_env=MAYHEM_URL=${{ env.MAYHEM_URL }} --action_env=XDG_CONFIG_HOME="%USERPROFILE%\.config" //examples:download_mayhemit
+        shell: cmd
         env:
           MAYHEM_URL: ${{ env.MAYHEM_URL }}

--- a/.github/workflows/small-win-test.yaml
+++ b/.github/workflows/small-win-test.yaml
@@ -66,6 +66,6 @@ jobs:
 
       - name: Run download
         run: |
-          bazel run --action_env=MAYHEM_URL=${{ env.MAYHEM_URL }} --action_env=XDG_CONFIG_HOME="%USERPROFILE%\.config" //examples:download_mayhemit
+          bazel build --action_env=MAYHEM_URL=${{ env.MAYHEM_URL }} --action_env=XDG_CONFIG_HOME="%USERPROFILE%\.config" //examples:download_mayhemit
         env:
           MAYHEM_URL: ${{ env.MAYHEM_URL }}

--- a/.github/workflows/small-win-test.yaml
+++ b/.github/workflows/small-win-test.yaml
@@ -63,4 +63,9 @@ jobs:
         shell: cmd
         env:
           MAYHEM_URL: ${{ env.MAYHEM_URL }}
-          MAYHEM_TOKEN: ${{ secrets.MAYHEM_TOKEN }}
+
+      - name: Run download
+        run: |
+          bazel run --action_env=MAYHEM_URL=${{ env.MAYHEM_URL }} --action_env=XDG_CONFIG_HOME="%USERPROFILE%\.config" //examples:download_mayhemit
+        env:
+          MAYHEM_URL: ${{ env.MAYHEM_URL }}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_mayhem",
-    version = "0.8.1",
+    version = "0.8.2",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -138,8 +138,8 @@
   "moduleExtensions": {
     "//mayhem:extensions.bzl%rules_mayhem_extension": {
       "general": {
-        "bzlTransitiveDigest": "OxwdHM3+qUqeK9RcP5SfwwI70h7i1WHlsyNNj8pQctE=",
-        "usagesDigest": "XE0utA0bpUHCiv0xi9mfp5fgoEEJyHRfSMaXWPOwF0A=",
+        "bzlTransitiveDigest": "QXrwS+MaUXAuRADmpi4iR+vh8m0INIiGS8EaMviNSUs=",
+        "usagesDigest": "ZKttRTAXvQeHIHxQrsY8nAdZUjOP2qqgZipsJGQtg0I=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -143,7 +143,7 @@
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {
-          "MAYHEM_URL": "https://app.mayhem.security"
+          "MAYHEM_URL": null
         },
         "generatedRepoSpecs": {
           "mayhem_cli_linux": {

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -138,7 +138,7 @@
   "moduleExtensions": {
     "//mayhem:extensions.bzl%rules_mayhem_extension": {
       "general": {
-        "bzlTransitiveDigest": "QXrwS+MaUXAuRADmpi4iR+vh8m0INIiGS8EaMviNSUs=",
+        "bzlTransitiveDigest": "OxwdHM3+qUqeK9RcP5SfwwI70h7i1WHlsyNNj8pQctE=",
         "usagesDigest": "XE0utA0bpUHCiv0xi9mfp5fgoEEJyHRfSMaXWPOwF0A=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You can add the following snippet:
 
 ```
 ## MODULE.bazel
-bazel_dep(name = "rules_mayhem", version = "0.8.1")
+bazel_dep(name = "rules_mayhem", version = "0.8.2")
 
 rules_mayhem_extension = use_extension("@rules_mayhem//mayhem:extensions.bzl", "rules_mayhem_extension")
 use_repo(rules_mayhem_extension, "bazel_skylib", "mayhem_cli_linux", "mayhem_cli_windows", "platforms", "yq_cli_linux", "yq_cli_windows")
@@ -21,8 +21,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "rules_mayhem",
     strip_prefix = "rules_mayhem",
-    urls = ["https://github.com/ForAllSecure/rules_mayhem/releases/download/0.8.1/rules_mayhem-0.8.1.tar.gz"],
-    sha256 = "14050b80f5fbbec8f6ddc6ff897b2d7ecb690b84f05ac3049405ef17f614a938",
+    urls = ["https://github.com/ForAllSecure/rules_mayhem/releases/download/0.8.2/rules_mayhem-0.8.2.tar.gz"],
+    sha256 = "b1713ca37ab5ec8551514ae7a34eb79ac4a380508e89967c1f672b020eadc528",
 )
 
 load("@rules_mayhem//mayhem:repositories.bzl", "rules_mayhem_repositories")

--- a/mayhem/mayhem.bzl
+++ b/mayhem/mayhem.bzl
@@ -133,7 +133,9 @@ def mayhem_login(ctx, mayhem_cli, mayhem_cli_exe, is_windows):
     """
     mayhem_login_out = ctx.actions.declare_file(ctx.label.name + "-login.out")
 
-    if is_windows and mayhem_cli_exe is not None:
+    if is_windows:
+        if mayhem_cli_exe == None:
+            mayhem_cli_exe = create_or_retrieve_windows_symlink(ctx, mayhem_cli.path)
         login_wrapper = ctx.actions.declare_file(ctx.label.name + "-login.bat")
         login_wrapper_content = """
         @echo off

--- a/mayhem/mayhem.bzl
+++ b/mayhem/mayhem.bzl
@@ -326,7 +326,6 @@ def _mayhem_run_impl(ctx):
             output_file=mayhem_out.path,
         )
 
-
     # Ideally, ctx.actions.run() would support capturing stdout/stderr
     # as described in https://github.com/bazelbuild/bazel/issues/5511
     # Or, the mayhem cli itself could support an output flag
@@ -465,7 +464,7 @@ def _mayhem_download_impl(ctx):
         output_dir = ctx.actions.declare_directory(ctx.attr.output_dir)
     else:
         output_dir = ctx.actions.declare_directory(ctx.attr.target + "-pkg")
-    mayhem_cli_linux = ctx.executable._mayhem_cli
+    mayhem_cli = ctx.executable._mayhem_cli
     is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
 
     args = ctx.actions.args()
@@ -476,19 +475,6 @@ def _mayhem_download_impl(ctx):
         args.add(ctx.attr.owner + "/" + ctx.attr.project + "/" + ctx.attr.target)
     else:
         args.add(ctx.attr.project + "/" + ctx.attr.target)
-
-    if is_windows:
-         # Need to copy the Mayhem CLI to have .exe extension
-        mayhem_cli_exe = ctx.actions.declare_file(ctx.executable._mayhem_cli.path + ".exe")
-
-        ctx.actions.symlink(
-            output = mayhem_cli_exe,
-            target_file = ctx.executable._mayhem_cli,
-            is_executable = True,
-        )
-        mayhem_cli = mayhem_cli_exe
-    else:
-        mayhem_cli = mayhem_cli_linux
 
     ctx.actions.run(
         outputs = [output_dir],
@@ -503,7 +489,6 @@ def _mayhem_download_impl(ctx):
             files = depset([output_dir]),
         ),
     ]
-    
 
 
 mayhem_download = rule(

--- a/mayhem/mayhem.bzl
+++ b/mayhem/mayhem.bzl
@@ -366,7 +366,7 @@ def _mayhem_run_impl(ctx):
 
     if is_windows:
         # Need to copy the Mayhem CLI to have .exe extension
-        mayhem_cli_exe = ctx.actions.declare_symlink(ctx.executable._mayhem_cli + ".exe")
+        mayhem_cli_exe = ctx.actions.declare_file(ctx.executable._mayhem_cli + ".exe")
 
         ctx.actions.symlink(
             output = mayhem_cli_exe,

--- a/mayhem/mayhem.bzl
+++ b/mayhem/mayhem.bzl
@@ -96,82 +96,6 @@ mayhem_init = rule(
     },
 )
 
-# def create_or_retrieve_windows_symlink(ctx, mayhem_cli_path):
-#     """ Creates a Windows symlink for the Mayhem CLI
-    
-#     Args:
-#         ctx: The context
-#         mayhem_cli_path: The path to the Mayhem CLI executable
-    
-#     Returns:
-#         mayhem_cli_exe: The path to the Mayhem CLI with .exe extension
-#     """
-#     # Check if file already exists
-#     mayhem_cli_exe = mayhem_cli_path + ".exe"
-#     if mayhem_cli_exe.exists():
-#         return mayhem_cli_exe
-#     else:
-#         mayhem_cli_exe = ctx.actions.declare_symlink(mayhem_cli_path + ".exe")
-#         ctx.actions.symlink(
-#             output = mayhem_cli_exe,
-#             target_file = ctx.executable._mayhem_cli,
-#             is_executable = True,
-#         )
-
-#     return mayhem_cli_exe
-
-# def mayhem_login(ctx, mayhem_cli, mayhem_cli_exe, is_windows):
-#     """ Logs into Mayhem 
-    
-#     Args:
-#         ctx: The context
-#         mayhem_cli: The path to the Mayhem CLI
-#         mayhem_cli_exe: The path to the Mayhem CLI with .exe extension, or None if we are on Linux
-#         is_windows: A boolean indicating if the OS is Windows
-#     Returns:
-#         mayhem_login_out: The Mayhem login output file
-#     """
-#     mayhem_login_out = ctx.actions.declare_file(ctx.label.name + "-login.out")
-
-#     if is_windows:
-#         login_wrapper = ctx.actions.declare_file(ctx.label.name + "-login.bat")
-#         login_wrapper_content = """
-#         @echo off
-#         setlocal
-#         {mayhem_cli} login > {output_file}
-#         """.format(
-#             mayhem_cli=mayhem_cli_exe.path.replace("/", "\\"),
-#             output_file=mayhem_login_out.path.replace("/", "\\"),
-#         )
-#     else:
-#         login_wrapper = ctx.actions.declare_file(ctx.label.name + "-login.sh")
-#         login_wrapper_content = """
-#         #!/bin/bash
-#         {mayhem_cli} login > {output_file}
-#         """.format(
-#             mayhem_cli=mayhem_cli.path,
-#             output_file=mayhem_login_out.path,
-#         )
-
-#     ctx.actions.write(
-#         output=login_wrapper,
-#         content=login_wrapper_content
-#     )
-
-#     inputs = [mayhem_cli, login_wrapper]
-
-#     ctx.actions.run(
-#         inputs = inputs,
-#         outputs = [mayhem_login_out],
-#         executable = login_wrapper,
-#         progress_message = "Logging into Mayhem...",
-#         use_default_shell_env = True,
-#     )
-
-#     return mayhem_login_out
-
-
-
 def mayhem_wait(ctx, mayhem_cli, mayhem_cli_exe, mayhem_out, is_windows, junit, sarif, fail_on_defects):
     """ Waits for Mayhem to finish
     
@@ -365,8 +289,8 @@ def _mayhem_run_impl(ctx):
         args_list.append("--insecure")
 
     if is_windows:
-        # Need to copy the Mayhem CLI to have .exe extension
-        mayhem_cli_exe = ctx.actions.declare_file(ctx.executable._mayhem_cli + ".exe")
+         # Need to copy the Mayhem CLI to have .exe extension
+        mayhem_cli_exe = ctx.actions.declare_symlink(ctx.executable._mayhem_cli.path + ".exe")
 
         ctx.actions.symlink(
             output = mayhem_cli_exe,
@@ -402,9 +326,6 @@ def _mayhem_run_impl(ctx):
             output_file=mayhem_out.path,
         )
 
-    # Login first
-    # mayhem_login_out = mayhem_login(ctx, ctx.executable._mayhem_cli, mayhem_cli_exe, is_windows)
-    # inputs.append(mayhem_login_out)
 
     # Ideally, ctx.actions.run() would support capturing stdout/stderr
     # as described in https://github.com/bazelbuild/bazel/issues/5511
@@ -545,16 +466,6 @@ def _mayhem_download_impl(ctx):
     else:
         output_dir = ctx.actions.declare_directory(ctx.attr.target + "-pkg")
     mayhem_cli = ctx.executable._mayhem_cli
-    # is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
-
-    # if is_windows:
-    #     # Create a symlink for the Mayhem CLI with .exe extension
-    #     mayhem_cli_exe = create_or_retrieve_windows_symlink(ctx, ctx.executable._mayhem_cli.path)
-    # else:
-    #     mayhem_cli_exe = None
-
-    # mayhem_login(ctx, ctx.executable._mayhem_cli, mayhem_cli_exe, is_windows)
-
 
     args = ctx.actions.args()
     args.add("download")

--- a/mayhem/mayhem.bzl
+++ b/mayhem/mayhem.bzl
@@ -290,7 +290,7 @@ def _mayhem_run_impl(ctx):
 
     if is_windows:
          # Need to copy the Mayhem CLI to have .exe extension
-        mayhem_cli_exe = ctx.actions.declare_symlink(ctx.executable._mayhem_cli.path + ".exe")
+        mayhem_cli_exe = ctx.actions.declare_file(ctx.executable._mayhem_cli.path + ".exe")
 
         ctx.actions.symlink(
             output = mayhem_cli_exe,


### PR DESCRIPTION
Due to challenges with reliably creating/finding symlinks on Windows, this rule has now migrated to fully implicit login - that is, creating the login file in the `XDG_CONFIG_HOME` directory. 